### PR TITLE
Fix #update implementation and use bang methods

### DIFF
--- a/lessons/Assignment-7_1-Active-Record-Associations.md
+++ b/lessons/Assignment-7_1-Active-Record-Associations.md
@@ -210,12 +210,12 @@ Ok, now we fill in the methods, one at a time.  Note that for some of them, noth
 ```ruby
 def create
   @post = @forum.posts.new(post_params)  # we create a new post for the current forum
-  @post.save
+  @post.save!
   redirect_to @post, notice: "Your post was created."
 end
 
 def new
-  @post = @forum.posts.new  
+  @post = @forum.posts.new
 end
 
 def edit    # nothing to do here
@@ -225,14 +225,13 @@ def show    # nothing to do here
 end
 
 def update
-  @post = Post.new(post_params)
-  @post.save
+  @post.update!(post_params)
   redirect_to @post, notice: "Your post was updated."
 end
 
 def destroy
   @forum = @post.forum # we need to save this, so we can redirect to the forum after the destroy
-  @post.destroy
+  @post.destroy!
   redirect_to @forum, notice: "Your post was deleted."
 end
 ```


### PR DESCRIPTION
* The `save` call was always failing because there is no forum ID on the form, which every post needs, and `@post = Post.new(post_params)` overwrites the `@post` set in the `before_action`.
* Calling non-bang methods without checking the result is unsafe because they allow for silent failures. We should incorporate this distinction into the lessons somehow, but for the immediate future, let's just make it harder for students to encounter these surprises.

Context for how I found this: https://codethedream.slack.com/archives/C073D668T9C/p1721610970861889

