### PR TITLE
Fix Lesson 7 Typos

### DIFF
--- a/lessons/Assignment-7_1-Active-Record-Associations.md
+++ b/lessons/Assignment-7_1-Active-Record-Associations.md
@@ -168,7 +168,7 @@ Note the use of percent notation below to create arrays.  Review percent notatio
   before_action :check_logon, except: %w[show]
   before_action :set_forum, only: %w[create new]
   before_action :set_post, only: %w[show edit update destroy]
-  before_action :check_access, only: %w[edit update delete] # access control!! a user can only
+  before_action :check_access, only: %w[edit update destroy] # access control!! a user can only
                                        # edit or update or delete their own posts
 
 # at the bottom
@@ -189,13 +189,13 @@ private
   end
 
   def check_access
-    if @post.user_id != session[:current_user][:id]
+    if @post.user_id != @current_user.id
       redirect_to forums_path, notice: "That's not your post, so you can't change it."
     end
   end
 
   def post_params   # security check, also known as "strong parameters"
-    params[:post][:user_id] = session[:current_user]["id"] 
+    params[:post][:user_id] = @current_user.id
        # here we have to add a parameter so that the post is associated with the current user
     params.require(:post).permit(:title,:content,:user_id)
   end


### PR DESCRIPTION
A student reported they were having an issue with the lesson 7 assignment. 

Upon proof-reading, I noticed that there were a few errors in the code students were being asked to copy and paste:

- `:delete` is not a controller action [2.2 CRUD, Verbs, and Actions](https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions)
- The `#logon` method students [created in lesson 6](https://github.com/Code-the-Dream-School/R7-forum/blob/main/lessons/Assignment-6-Rails-Introduction.md#step-4-simulating-logon) sets `session[:current_user]` to an integer. There is no `session[:current_user][:id]`. 
  - Students should be guided to use the instance variable initialized in the `ApplicationController#set_current_user` instead.